### PR TITLE
[FILE UPLOAD] fix regex size extension and add default value

### DIFF
--- a/Util/FileUploader.php
+++ b/Util/FileUploader.php
@@ -154,8 +154,10 @@ class FileUploader
                     $size = intval($sizeRegex[1])*10000;
                     break;
                 default: 
-                    $size =  ini_get('upload_max_filesize');
+                    $size = intval($sizeRegex[1]);
             }
+        } elseif (isset($sizeRegex[1])) { 
+            $size = intval($sizeRegex[1]); 
         } else {
             $size =  ini_get('upload_max_filesize');
         }

--- a/Util/FileUploader.php
+++ b/Util/FileUploader.php
@@ -141,7 +141,7 @@ class FileUploader
 
     private function extractSize($value)
     {
-        preg_match('/([0-9+])([A-Z]?)/', $value, $sizeRegex);
+        preg_match('/([0-9]+)([A-Z]?)/', $value, $sizeRegex);
         if (isset($sizeRegex[2])) {
             switch ($sizeRegex[2]) {
                 case 'K':
@@ -153,6 +153,8 @@ class FileUploader
                 case 'G':
                     $size = intval($sizeRegex[1])*10000;
                     break;
+                default: 
+                    $size =  ini_get('upload_max_filesize');
             }
         } else {
             $size =  ini_get('upload_max_filesize');


### PR DESCRIPTION
While installing the bundle with default configuration on Symfony 4, I received an error when trying to create a new post.

ErrorException:
Notice: Undefined variable: size

  at vendor/yosimitso/workingforumbundle/Util/FileUploader.php:162
  at Yosimitso\WorkingForumBundle\Util\FileUploader->extractSize('100M')
     (vendor/yosimitso/workingforumbundle/Util/FileUploader.php:133)
  at Yosimitso\WorkingForumBundle\Util\FileUploader->getMaxSize()
     (vendor/yosimitso/workingforumbundle/Controller/ThreadController.php:309)
  at Yosimitso\WorkingForumBundle\Controller\ThreadController->newAction('conseils', object(Request))
     (vendor/symfony/http-kernel/HttpKernel.php:150)
  at Symfony\Component\HttpKernel\HttpKernel->handleRaw(object(Request), 1)
     (vendor/symfony/http-kernel/HttpKernel.php:67)
  at Symfony\Component\HttpKernel\HttpKernel->handle(object(Request), 1, true)
     (vendor/symfony/http-kernel/Kernel.php:198)
  at Symfony\Component\HttpKernel\Kernel->handle(object(Request))
     (public/index.php:25)
