### PR TITLE
Replacing TokenStorage by its interface

### DIFF
--- a/Security/Authorization.php
+++ b/Security/Authorization.php
@@ -2,7 +2,7 @@
 
 namespace Yosimitso\WorkingForumBundle\Security;
 use Symfony\Component\Security\Core\Authorization\AuthorizationChecker;
-use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 
 /**
  * Class Authorization
@@ -30,11 +30,11 @@ class Authorization
 
     /**
      * Authorization constructor.
-     * @param \Symfony\Component\Security\Core\Authorization\AuthorizationChecker $securityChecker
+     * @param AuthorizationChecker $securityChecker
      * @param $tokenStorage
      * @param $allowAnonymousRead
      */
-    public function __construct(\Symfony\Component\Security\Core\Authorization\AuthorizationChecker $securityChecker, TokenStorage $tokenStorage, $allowAnonymousRead) {
+    public function __construct(AuthorizationChecker $securityChecker, TokenStorageInterface $tokenStorage, $allowAnonymousRead) {
         $this->securityChecker = $securityChecker;
         $this->tokenStorage = $tokenStorage;
         $this->allowAnonymousRead = $allowAnonymousRead;


### PR DESCRIPTION
Hi,

In Symfony 4.4, you'll get some errors because the type asked for in Authorization is TokenStorage instead of TokenStorageInterface

Here is a fix for that